### PR TITLE
Implement importing private keys to the YubiKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "group",
  "rand_core",
  "subtle",
+ "zeroize 1.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ dialoguer = "0.7"
 elliptic-curve = "0.6"
 gumdrop = "0.8"
 hex = "0.4"
-p256 = "0.5"
+p256 = {version = "0.5", features = ["zeroize"]}
 rand = "0.7"
 ring = "0.16.15"
 secrecy = "0.7"


### PR DESCRIPTION
This comes in two varieties:

1. Randomly generating a new key on the computer and then importing it.
   This option prints the newly generated key to stderr in hex form.
2. Accepting a hex input from the user.

The use case I have for those is as follows: I'd like to be able to
generate a private key in a secure environment[1] such that I can both
create a secure backup of it[2] and import it to my YubiKey for day to
day operations, so that if my YubiKey is lost or destroyed[3] I can buy
a new one and keep using my private key or even, in an emergency
scenario, use the private key (again, in a secure environment) to
decrypt some data in software directly if needed.

I hope the warnings mentioning risks associated with importing keys are
appropriate, I'd like the potential users of this to understand them.

This has been tested with YubiKey 4.

[1] Ideally trusted hardware, air-gapped, booted from a live CD etc.
[2] Encrypted using a strong passphrase, stored in a safe place
[3] Granted, if the YubiKey is actually *lost* a key rotation is
    probably a good idea anyway.