### PR TITLE
Don't print message if YubiKey is waiting for touch

### DIFF
--- a/i18n/en-US/age_plugin_yubikey.ftl
+++ b/i18n/en-US/age_plugin_yubikey.ftl
@@ -164,8 +164,6 @@ plugin-err-pin-too-short    = PIN was too short.
 plugin-err-pin-too-long     = PIN was too long.
 plugin-err-pin-required     = A PIN is required for {-yubikey} with serial {$yubikey_serial}
 
-plugin-touch-yk = 👆 Please touch the {-yubikey}
-
 ## Errors
 
 err-custom-mgmt-key      = Custom unprotected management keys are not supported.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -222,7 +222,7 @@ impl IdentityPluginV1 for IdentityPlugin {
                 }
 
                 for (stanza_index, line) in stanzas.iter().enumerate() {
-                    match conn.unwrap_file_key(line, &mut callbacks)? {
+                    match conn.unwrap_file_key(line) {
                         Ok(file_key) => {
                             // We've managed to decrypt this file!
                             file_keys.entry(file_index).or_insert(Ok(file_key));


### PR DESCRIPTION
The user call-to-action will instead be implemented on the client side, where it can be done in a more forgiving way (allowing the user some time to react before prompting them that it is waiting on the plugin).