### PR TITLE
Request PIN before certificate generation if PIN policy is "always"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ to 0.3.0 are beta releases.
     `age-plugin-yubikey` won't request a PIN entry to decrypt a file with an
     identity that has a PIN policy of `once`.
 
+### Fixed
+- Identities can now be generated with a PIN policy of "always" (in previous
+  versions of `age-plugin-yubikey` this would cause an error).
+
 ## [0.3.2] - 2023-01-01
 ### Changed
 - The "sharing violation" logic now also sends SIGHUP to any `yubikey-agent`

--- a/i18n/en-US/age_plugin_yubikey.ftl
+++ b/i18n/en-US/age_plugin_yubikey.ftl
@@ -144,6 +144,12 @@ mgr-changing-mgmt-key-error =
     {"  "}{$management_key}
 mgr-changing-mgmt-key-success = Success!
 
+## YubiKey keygen
+
+builder-gen-key  = 🎲 Generating key...
+builder-gen-cert = 🔏 Generating certificate...
+builder-touch-yk = 👆 Please touch the {-yubikey}
+
 ## Plugin usage
 
 plugin-err-invalid-recipient = Invalid recipient


### PR DESCRIPTION
We also correctly ask for a PIN touch after the key is generated (which does not need it) but before certificate generation (which does if the touch policy is not "none").

Closes str4d/age-plugin-yubikey#101.