### PR TITLE
Update README.md to install required libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ brew install age-plugin-yubikey
 On non-Windows, non-macOS systems, you need to ensure that the `pcscd` service
 is installed and running. 
 
+You'll also need the related library in order to build the pcsc-sys dependency.
+Otherwise you'll have a build error saying: 
+```
+error: failed to run custom build command for `pcsc-sys v1.2.0`
+```
+
 #### Debian or Ubuntu
 
 ```
-$ sudo apt-get install pcscd
+$ sudo apt-get install pcscd libpcsclite-dev
 ```
 
 #### OpenBSD


### PR DESCRIPTION
When installing on some devices that are coming with `pcscd` but without its dev libraries, one needs to install them manually.

This is adding the relevant error message and step to correct on Ubuntu to the readme.

I couldn't find it for FreeBSD and OpenBSD, so my assumption is that it's bundled with the `pcsc-lite` package.