### PR TITLE
Treat `pcsc::Error::NoSmartcard` as a "YubiKey disconnected" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to 0.3.0 are beta releases.
 - When `age-plugin-yubikey` assists the user in changing their PIN from the
   default PIN, it no longer tells the user that PINs shorter than 6 characters
   are allowed, and instead loops until the user enters a PIN of valid length.
+- More kinds of SmartCard readers are ignored when they have no SmartCard
+  inserted.
 
 ## [0.3.2] - 2023-01-01
 ### Changed

--- a/src/key.rs
+++ b/src/key.rs
@@ -41,7 +41,7 @@ pub(crate) fn is_connected(reader: Reader) -> bool {
 pub(crate) fn filter_connected(reader: &Reader) -> bool {
     match reader.open() {
         Err(yubikey::Error::PcscError {
-            inner: Some(pcsc::Error::RemovedCard),
+            inner: Some(pcsc::Error::NoSmartcard | pcsc::Error::RemovedCard),
         }) => {
             warn!(
                 "{}",


### PR DESCRIPTION
Some SmartCard readers report this error when no SmartCard is inserted, so we need to check for it when filtering for connected YubiKeys (along with `pcsc::Error::RemovedCard` which some _other_ SmartCard readers report instead).

Closes str4d/age-plugin-yubikey#81.