### PR TITLE
Explicitly mention CCID packages for the two BSDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ sudo apt-get install pcscd
 As ```root``` do:
 
 ```
-$ pkg_add pcsc-lite
+$ pkg_add pcsc-lite ccid
 $ rcctl enable pcscd
 $ rcctl start pcscd
 ```
@@ -51,7 +51,7 @@ $ rcctl start pcscd
 
 As ```root``` do:
 ```
-$ pkg install pcsc-lite
+$ pkg install pcsc-lite libccid
 $ service pcscd enable
 $ service pcscd start
 ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,7 +107,7 @@ impl fmt::Debug for Error {
                         wlnfl!(f, "rec-yk-no-service-macos", url = url)?;
                     } else if cfg!(target_os = "openbsd") {
                         wlnfl!(f, "err-yk-no-service-pcscd")?;
-                        let pkg = "pkg_add pcsc-lite";
+                        let pkg = "pkg_add pcsc-lite ccid";
                         let service_enable = "rcctl enable pcscd";
                         let service_start = "rcctl start pcscd";
                         wlnfl!(
@@ -119,7 +119,7 @@ impl fmt::Debug for Error {
                         )?;
                     } else if cfg!(target_os = "freebsd") {
                         wlnfl!(f, "err-yk-no-service-pcscd")?;
-                        let pkg = "pkg install pcsc-lite";
+                        let pkg = "pkg install pcsc-lite libccid";
                         let service_enable = "service pcscd enable";
                         let service_start = "service pcscd start";
                         wlnfl!(


### PR DESCRIPTION
As mentioned in #112, the ccid/libccid packages may need to be installed for a yubikey to be recognized on OpenBSD and FreeBSD. That escaped me in my first patch.