### PR TITLE
Intercept PIN errors and replace with PUK errors as necessary

### DIFF
--- a/i18n/en-US/age_plugin_yubikey.ftl
+++ b/i18n/en-US/age_plugin_yubikey.ftl
@@ -223,9 +223,14 @@ rec-yk-no-service-win =
     {"  "}{$url}
 
 err-yk-not-found         = Please insert the {-yubikey} you want to set up
-err-yk-wrong-pin         = Invalid PIN ({$tries} tries remaining before it is blocked)
 err-yk-general           = Error while communicating with {-yubikey}: {$err}
 err-yk-general-cause     = Cause: {$inner_err}
+
+err-yk-wrong-pin = Invalid {$pin_kind} ({$tries ->
+    [one] {$tries} try remaining
+   *[other] {$tries} tries remaining
+} before it is blocked)
+err-yk-pin-locked = {$pin_kind} locked
 
 err-ux-A = Did this not do what you expected? Could an error be more useful?
 err-ux-B = Tell us

--- a/src/key.rs
+++ b/src/key.rs
@@ -333,7 +333,13 @@ pub(crate) fn manage(yubikey: &mut YubiKey) -> Result<(), Error> {
             }
         };
         let new_pin = new_pin.expose_secret();
-        yubikey.change_puk(current_puk.as_bytes(), new_pin.as_bytes())?;
+        yubikey
+            .change_puk(current_puk.as_bytes(), new_pin.as_bytes())
+            .map_err(|e| match e {
+                yubikey::Error::PinLocked => Error::PukLocked,
+                yubikey::Error::WrongPin { tries } => Error::WrongPuk(tries),
+                _ => Error::YubiKey(e),
+            })?;
         yubikey.change_pin(pin.as_bytes(), new_pin.as_bytes())?;
     }
 


### PR DESCRIPTION
Once iqlusioninc/yubikey.rs#479 is part of a `yubikey` release we can migrate to, this will mean that users get correctly notified of incorrect PUK entry, instead of being told it is an incorrect PIN issue.