### PR TITLE
Provide a better error message when management key authentication fails

### DIFF
--- a/i18n/en-US/age_plugin_yubikey.ftl
+++ b/i18n/en-US/age_plugin_yubikey.ftl
@@ -187,8 +187,12 @@ plugin-err-pin-required     = A PIN is required for {-yubikey} with serial {$yub
 
 ## Errors
 
+err-mgmt-key-auth = Failed to authenticate with the PIN-protected management key.
+rec-mgmt-key-auth =
+    Check whether your management key is using the TDES algorithm.
+    AES is not supported yet: {$aes_url}
 err-custom-mgmt-key = Custom unprotected non-TDES management keys are not supported.
-rec-custom-mgmt-key =
+rec-change-mgmt-key =
     You can use the {-yubikey} Manager CLI to change to a protected management key:
     {"  "}{$cmd}
 


### PR DESCRIPTION
We now indicate to the user that AES management key algorithms are not yet supported, and tell them how to change their management key to use TDES.

Closes str4d/age-plugin-yubikey#135.