### PR TITLE
Add Arch linux notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ is installed and running.
 | Debian or Ubuntu | `sudo apt-get install pcscd` |
 | OpenBSD | As ```root``` do:<br>`pkg_add pcsc-lite ccid`<br>`rcctl enable pcscd`<br>`rcctl start pcscd` |
 | FreeBSD | As ```root``` do:<br>`pkg install pcsc-lite libccid`<br>`service pcscd enable`<br>`service pcscd start` |
+| Arch | `sudo pacman -S pcsclite pcsc-tools yubikey-manager`<br>`sudo systemctl enable pcscd`<br>`sudo systemctl start pcscd`| 
 
 When installing via Cargo, you also need to ensure that the development headers
 for the `pcsc-lite` library are available, so that the `pcsc-sys` crate can be


### PR DESCRIPTION
I had `pcscd` already installed, but age-plugin-yubikey didn't work initially.

I installed `pcsc-tools` so I could do `pcsc_scan`, which also found nothing. Then I installed `yubikey-manager` so I could `ykman info`, which worked, but after that magically pcsc_scan and age-plugin-yubikey were working too.

Not sure if installing `yubikey-manager` had to do with it, but anyway.