### PR TITLE
Publish arm64 debian package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           - windows
         include:
           - name: linux
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             build_deps: >
               libpcsclite-dev
             archive_name: age-plugin-yubikey.tar.gz
@@ -95,13 +95,20 @@ jobs:
 
   deb:
     name: Debian ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        name: [linux]
+        name: [linux, linux-arm64]
         include:
           - name: linux
+            os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            build_deps: >
+              libpcsclite-dev
+
+          - name: linux-arm64
+            os: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
             build_deps: >
               libpcsclite-dev
 


### PR DESCRIPTION
This change uses `ubuntu-22.04-arm` environment to build the debian package. I've verified it by running the workflow on arm64-deb-force-publish branch, the resulting file can be found at https://github.com/egorich239/age-plugin-yubikey/releases/tag/arm64-deb-force-upload

One more thing I had to do, is switch from ubuntu 20.04 to 22.04, as the former is no longer supported by github:
https://github.com/actions/runner-images/issues/11101