### PR TITLE
fix: use ORGANIZATION_NAME OID (2.5.4.10) not ORGANIZATION (2.5.6.4) in extract_name

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use p256::pkcs8::{AssociatedOid, ObjectIdentifier};
 use x509_cert::{
     der::{
         self,
-        oid::db::rfc4519::{COMMON_NAME, ORGANIZATION},
+        oid::db::rfc4519::{COMMON_NAME, ORGANIZATION_NAME as ORGANIZATION},
         Decode,
     },
     ext::AsExtension,


### PR DESCRIPTION
## Summary

`util.rs` imports `rfc4519::ORGANIZATION` which is OID `2.5.6.4` — the **object class** OID for Organization, not the attribute type OID used in certificate subjects.

The correct import is `rfc4519::ORGANIZATION_NAME` which is OID `2.5.4.10` — the **attribute type** OID that `x509-cert` assigns when encoding `O=` attributes in a DN string via `Name::from_str`.

## Impact

Without this fix, `extract_name()` compares `a.oid == ORGANIZATION` (2.5.6.4) against every attribute in the generated certificate's subject, but the `O=age-plugin-yubikey` attribute is encoded with OID `2.5.4.10`. The comparison never matches, so `extract_name()` returns `None`, and the `.unwrap()` at `builder.rs:175` panics immediately after every successful `--generate` invocation:

```
thread 'main' panicked at src/builder.rs:175:71:
called `Option::unwrap()` on a `None` value
```

This means `--generate` always panics on the `update-yubikey` branch, even though the key and certificate are written to the YubiKey successfully before the panic.

## Fix

```diff
-        oid::db::rfc4519::{COMMON_NAME, ORGANIZATION},
+        oid::db::rfc4519::{COMMON_NAME, ORGANIZATION_NAME as ORGANIZATION},
```

One line. The alias `as ORGANIZATION` preserves all existing uses of the identifier throughout the file.

## Testing

Verified by running `age-plugin-yubikey --generate` against a YubiKey 5C Nano 2 (firmware 5.7.4, AES256 management key) with the patched binary. Generation completes without panic and produces a valid recipient + identity stub.