### PR TITLE
fix: mask cert serial MSB to prevent DER Overlength panic in --generate

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -115,6 +115,12 @@ impl IdentityBuilder {
         // Pick a random serial for the new self-signed certificate.
         let mut serial = [0; 20];
         OsRng.fill_bytes(&mut serial);
+        // RFC 5280 §4.1.2.2: serial is a DER INTEGER, max 20 bytes.
+        // If the MSB of the first byte is set, DER encoding prepends a 0x00
+        // sign-extension byte, making the encoded length 21 bytes and causing
+        // x509-cert / der to return Overlength (~50% probability).
+        // Mask the high bit to guarantee the value is positive and fits.
+        serial[0] &= 0x7f;
 
         let name = self
             .name


### PR DESCRIPTION
## Summary

`--generate` panics with `Overlength` at `builder.rs:127` on approximately every other invocation.

## Root cause

`builder.rs` generates a 20-byte random certificate serial and passes it directly to `SerialNumber::new`:

```rust
let mut serial = [0; 20];
OsRng.fill_bytes(&mut serial);
SerialNumber::new(&serial).expect("valid")   // panics ~50% of the time
```

A DER `INTEGER` requires a `0x00` sign-extension byte when the MSB of the first content byte is set (to indicate a positive value). For a 20-byte random array this happens ~50% of the time, producing a 21-byte encoding that exceeds the RFC 5280 §4.1.2.2 limit of 20 bytes. `x509-cert 0.2 / der 0.7` returns `Error { kind: Overlength, position: None }` and the `.expect("valid")` call panics with:

```
thread 'main' panicked at src/builder.rs:127:40:
valid: Error { kind: Overlength, position: None }
```

## Fix

Mask the high bit of the first byte before constructing `SerialNumber` to ensure the value is always non-negative and the DER encoding never exceeds 20 bytes:

```rust
serial[0] &= 0x7f;
```

This is the standard approach used by most X.509 certificate generators (see e.g. OpenSSL, rcgen, rustls-cert-gen). The existing TODO comment notes that `SerialNumber::generate` (RustCrypto/formats#1270) will eventually handle this correctly; until that lands, the manual mask is the correct fix.

## Testing

Verified on YubiKey 5C NFC (serial 37153875, firmware 5.7.4) with AES256 management key. Previously `--generate` failed consistently on this device (panicking at `builder.rs:127`). With this fix applied the command completes successfully and produces a valid recipient/identity stub.

Also related to / builds on top of #219 (wrong OID in `util.rs`).

## Note on branch base

This branch is based on the PR #190 branch (`str4d:yubikey-0.8`) which has not yet been merged. The fix applies equally to `main` once #190 merges — `serial[0] &= 0x7f` is a one-line change independent of the rest of the #190 changes.