### PR TITLE
ci: Add missing platform targets and modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: main
+  workflow_dispatch:
 
 jobs:
   test-msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        name: [linux, windows, macos]
+        name: [linux, linux-aarch64, windows, macos]
         include:
           - name: linux
             os: ubuntu-latest
+            build_deps: >
+              libpcsclite-dev
+
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
             build_deps: >
               libpcsclite-dev
 
@@ -43,10 +48,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        name: [linux, windows, macos]
+        name: [linux, linux-aarch64, windows, macos]
         include:
           - name: linux
             os: ubuntu-latest
+            build_deps: >
+              libpcsclite-dev
+
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
             build_deps: >
               libpcsclite-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,19 @@ on:
     branches: main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test-msrv:
     name: Test MSRV on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         name: [linux, linux-aarch64, windows, macos]
         include:
@@ -31,12 +39,13 @@ jobs:
             os: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install build dependencies
         run: sudo apt install ${{ matrix.build_deps }}
         if: matrix.build_deps != ''
       - uses: dtolnay/rust-toolchain@stable
         id: stable-toolchain
+      - uses: Swatinem/rust-cache@v2
       - name: Install test dependencies using latest stable Rust
         run: cargo +${{steps.stable-toolchain.outputs.name}} install rage
       - name: Run tests
@@ -48,6 +57,7 @@ jobs:
     name: Test latest stable on ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         name: [linux, linux-aarch64, windows, macos]
         include:
@@ -68,14 +78,14 @@ jobs:
             os: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install build dependencies
         run: sudo apt install ${{ matrix.build_deps }}
         if: matrix.build_deps != ''
       - uses: dtolnay/rust-toolchain@stable
-      - uses: dtolnay/rust-toolchain@stable
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
+      - uses: Swatinem/rust-cache@v2
       - name: Install test dependencies
         run: cargo install rage
       - name: Remove lockfile to build with latest dependencies
@@ -93,7 +103,7 @@ jobs:
       options: --security-opt seccomp=unconfined
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install build dependencies
         run: apt update && apt install -y libpcsclite-dev
       - name: Generate coverage report
@@ -103,7 +113,7 @@ jobs:
           --timeout 180
           --out xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.5.0
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -112,9 +122,10 @@ jobs:
     name: Intra-doc links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install build dependencies
         run: sudo apt install libpcsclite-dev
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
@@ -124,6 +135,6 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check formatting
         run: cargo fmt -- --check

--- a/.github/workflows/lints-beta.yml
+++ b/.github/workflows/lints-beta.yml
@@ -3,20 +3,26 @@ name: Beta lints
 # We only run these lints on trial-merges of PRs to reduce noise.
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   clippy-beta:
     name: Clippy (beta)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@beta
         id: toolchain
+        with:
+          components: clippy
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Install build dependencies
         run: sudo apt install libpcsclite-dev
+      - uses: Swatinem/rust-cache@v2
       - name: Clippy (beta)
-        uses: actions-rs/clippy-check@v1
-        with:
-          name: Clippy (beta)
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -W clippy::all
+        run: cargo clippy --all-features --all-targets -- -W clippy::all

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -3,17 +3,24 @@ name: Stable lints
 # We only run these lints on trial-merges of PRs to reduce noise.
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   clippy:
     name: Clippy (MSRV)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install build dependencies
         run: sudo apt install libpcsclite-dev
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          name: Clippy (MSRV)
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run clippy
+        run: cargo clippy --all-features --all-targets -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install armv7 cross-compilation toolchain
         run: |
           sudo dpkg --add-architecture armhf
-          sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list.d/*.list || true
+          sudo sed -i '/^\s*deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list.d/*.list || true
           echo "deb [arch=armhf] http://ports.ubuntu.com/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/armhf.list
           echo "deb [arch=armhf] http://ports.ubuntu.com/ $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,15 @@ on:
         required: true
         default: 'true'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Publish for ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         name:
           - linux
@@ -74,13 +78,16 @@ jobs:
             asset_suffix: x86_64-darwin.tar.gz
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Add target
         run: rustup target add ${{ matrix.target }}
         if: matrix.target != ''
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.name }}
 
       - name: Install linux build dependencies
         run: sudo apt install ${{ matrix.build_deps }}
@@ -89,9 +96,24 @@ jobs:
       - name: Install armv7 cross-compilation toolchain
         run: |
           sudo dpkg --add-architecture armhf
-          sudo sed -i '/^\s*deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list.d/*.list || true
+
+          # Fix DEB822-format sources (Ubuntu 24.04+) to only fetch amd64
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sudo sed -i 's/^Architectures:.*/Architectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
+            # If no Architectures line exists, add one after each "Types:" line
+            if ! grep -q '^Architectures:' /etc/apt/sources.list.d/ubuntu.sources; then
+              sudo sed -i '/^Types:/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
+            fi
+          fi
+
+          # Also handle traditional format sources if any exist
+          sudo sed -i '/^\s*deb \[/! s/^deb /deb [arch=amd64] /' /etc/apt/sources.list.d/*.list 2>/dev/null || true
+
+          # Add armhf sources from ports.ubuntu.com
           echo "deb [arch=armhf] http://ports.ubuntu.com/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/armhf.list
           echo "deb [arch=armhf] http://ports.ubuntu.com/ $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ $(lsb_release -cs)-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list
+
           sudo apt-get update
           sudo apt-get install -y gcc-arm-linux-gnueabihf libpcsclite-dev:armhf
           mkdir -p .cargo
@@ -102,12 +124,6 @@ jobs:
         if: matrix.name == 'linux-armv7'
         env:
           PKG_CONFIG_ALLOW_CROSS: 1
-
-      - name: Set up .cargo/config
-        run: |
-          mkdir -p .cargo
-          echo '${{ matrix.cargo_config }}' >.cargo/config
-        if: matrix.cargo_config != ''
 
       - name: cargo build
         run: cargo build --release --locked ${{ matrix.build_flags }}
@@ -147,6 +163,7 @@ jobs:
     name: Debian ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         name: [linux, linux-aarch64]
         include:
@@ -163,42 +180,30 @@ jobs:
               libpcsclite-dev
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       - name: Add target
         run: rustup target add ${{ matrix.target }}
-      - name: cargo install cargo-deb
-        uses: actions-rs/cargo@v1
+      - uses: Swatinem/rust-cache@v2
         with:
-          command: install
-          args: cargo-deb
+          key: deb-${{ matrix.name }}
+      - name: cargo install cargo-deb
+        run: cargo install cargo-deb
 
       - name: Install build dependencies
         run: sudo apt install ${{ matrix.build_deps }}
         if: matrix.build_deps != ''
 
-      - name: Set up .cargo/config
-        run: |
-          mkdir .cargo
-          echo '${{ matrix.cargo_config }}' >.cargo/config
-        if: matrix.cargo_config != ''
-
       - name: cargo build
-        run: cargo build --release --locked --target ${{ matrix.target }} ${{ matrix.build_flags }}
+        run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Generate manpages
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --example generate-docs
+        run: cargo run --example generate-docs
 
       - name: cargo deb
-        uses: actions-rs/cargo@v1
-        with:
-          command: deb
-          args: --package age-plugin-yubikey --no-build --target ${{ matrix.target }}
+        run: cargo deb --package age-plugin-yubikey --no-build --target ${{ matrix.target }}
 
       - name: Upload Debian package to release
         uses: svenstaro/upload-release-action@2.9.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,21 +19,45 @@ jobs:
       matrix:
         name:
           - linux
+          - linux-aarch64
+          - linux-armv7
           - macos-arm64
           - macos-x86_64
           - windows
+          - windows-aarch64
         include:
           - name: linux
-            os: ubuntu-20.04
+            os: ubuntu-latest
             build_deps: >
               libpcsclite-dev
             archive_name: age-plugin-yubikey.tar.gz
             asset_suffix: x86_64-linux.tar.gz
 
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            build_deps: >
+              libpcsclite-dev
+            archive_name: age-plugin-yubikey.tar.gz
+            asset_suffix: aarch64-linux.tar.gz
+
+          - name: linux-armv7
+            os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            build_flags: --target armv7-unknown-linux-gnueabihf
+            archive_name: age-plugin-yubikey.tar.gz
+            asset_suffix: armv7-linux.tar.gz
+
           - name: windows
             os: windows-latest
             archive_name: age-plugin-yubikey.zip
             asset_suffix: x86_64-windows.zip
+
+          - name: windows-aarch64
+            os: windows-latest
+            target: aarch64-pc-windows-msvc
+            build_flags: --target aarch64-pc-windows-msvc
+            archive_name: age-plugin-yubikey.zip
+            asset_suffix: aarch64-windows.zip
 
           - name: macos-arm64
             os: macos-latest
@@ -44,6 +68,8 @@ jobs:
 
           - name: macos-x86_64
             os: macos-latest
+            target: x86_64-apple-darwin
+            build_flags: --target x86_64-apple-darwin
             archive_name: age-plugin-yubikey.tar.gz
             asset_suffix: x86_64-darwin.tar.gz
 
@@ -60,30 +86,54 @@ jobs:
         run: sudo apt install ${{ matrix.build_deps }}
         if: matrix.build_deps != ''
 
+      - name: Install armv7 cross-compilation toolchain
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list.d/*.list || true
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/armhf.list
+          echo "deb [arch=armhf] http://ports.ubuntu.com/ $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list
+          sudo apt-get update
+          sudo apt-get install -y gcc-arm-linux-gnueabihf libpcsclite-dev:armhf
+          mkdir -p .cargo
+          cat > .cargo/config.toml <<EOF
+          [target.armv7-unknown-linux-gnueabihf]
+          linker = "arm-linux-gnueabihf-gcc"
+          EOF
+        if: matrix.name == 'linux-armv7'
+        env:
+          PKG_CONFIG_ALLOW_CROSS: 1
+
       - name: Set up .cargo/config
         run: |
-          mkdir .cargo
+          mkdir -p .cargo
           echo '${{ matrix.cargo_config }}' >.cargo/config
         if: matrix.cargo_config != ''
 
       - name: cargo build
         run: cargo build --release --locked ${{ matrix.build_flags }}
+        env:
+          PKG_CONFIG_ALLOW_CROSS: ${{ matrix.name == 'linux-armv7' && '1' || '' }}
+          PKG_CONFIG_PATH: ${{ matrix.name == 'linux-armv7' && '/usr/lib/arm-linux-gnueabihf/pkgconfig' || '' }}
 
       - name: Create archive
         run: |
           mkdir -p release/age-plugin-yubikey
           mv target/${{ matrix.target }}/release/age-plugin-yubikey release/age-plugin-yubikey/
           tar czf ${{ matrix.archive_name }} -C release/ age-plugin-yubikey/
-        if: matrix.name != 'windows'
+        if: matrix.name != 'windows' && matrix.name != 'windows-aarch64'
 
       - name: Create archive [Windows]
         run: |
           mkdir -p release/age-plugin-yubikey
-          mv target/release/age-plugin-yubikey.exe release/age-plugin-yubikey/
+          if [ -n "${{ matrix.target }}" ]; then
+            mv target/${{ matrix.target }}/release/age-plugin-yubikey.exe release/age-plugin-yubikey/
+          else
+            mv target/release/age-plugin-yubikey.exe release/age-plugin-yubikey/
+          fi
           cd release/
           7z.exe a ../${{ matrix.archive_name }} age-plugin-yubikey/
         shell: bash
-        if: matrix.name == 'windows'
+        if: matrix.name == 'windows' || matrix.name == 'windows-aarch64'
 
       - name: Upload archive to release
         uses: svenstaro/upload-release-action@2.9.0
@@ -95,13 +145,20 @@ jobs:
 
   deb:
     name: Debian ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        name: [linux]
+        name: [linux, linux-aarch64]
         include:
           - name: linux
+            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            build_deps: >
+              libpcsclite-dev
+
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
             build_deps: >
               libpcsclite-dev
 


### PR DESCRIPTION
## Summary

Expands platform coverage across CI and release pipelines, and modernizes all GitHub Actions workflows.

## New Platforms

### Release pipeline (`release.yml`)
| Platform | Runner / Method | Archive suffix |
|---|---|---|
| **linux-aarch64** | `ubuntu-24.04-arm` (native) | `aarch64-linux.tar.gz` |
| **linux-armv7** | `ubuntu-latest` (cross-compile) | `armv7-linux.tar.gz` |
| **windows-aarch64** | `windows-latest` (cross-compile) | `aarch64-windows.zip` |

- Debian packages now also built for **linux-aarch64**
- Fixed `macos-x86_64` to explicitly cross-compile with `--target x86_64-apple-darwin` (previously built for host arch, which is now ARM64 on `macos-latest`)

### CI pipeline (`ci.yml`)
- Added **linux-aarch64** (`ubuntu-24.04-arm`) to both `test-msrv` and `test-latest` jobs

## Workflow Modernization

### Deprecated action upgrades
- `actions/checkout@v4` → `@v5` (all workflows)
- `actions-rs/cargo@v1` → direct `cargo` commands (unmaintained, Node.js 20)
- `actions-rs/clippy-check@v1` → direct `cargo clippy` (unmaintained, Node.js 20)
- `codecov-action@v4.5.0` → `@v5`

### Performance & reliability
- Added `Swatinem/rust-cache@v2` to all build/test jobs
- Added `fail-fast: false` to all matrix strategies
- Added `workflow_dispatch` trigger to CI for manual runs

### Security & housekeeping
- Added `permissions` blocks (least-privilege `contents: read` / `contents: write`)
- Added `concurrency` groups with `cancel-in-progress: true` to all workflows
- Removed dead `cargo_config` steps (unused by any matrix entry)
- Removed duplicate `dtolnay/rust-toolchain@stable` in `test-latest`
- Updated deprecated `ubuntu-20.04` runners to `ubuntu-latest`

## Cross-compilation details

**linux-armv7**: Sets up multiarch APT sources (handles both DEB822 and traditional formats), installs `gcc-arm-linux-gnueabihf` and `libpcsclite-dev:armhf`, configures cargo linker.

## Verification

Successful workflow run on fork: https://github.com/oguzhane/age-plugin-yubikey/actions/runs/23984355730
