### PR TITLE
Add AGE_PLUGIN_YUBIKEY_SKIP_NOT_FOUND env var to skip absent serials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ to 0.3.0 are beta releases.
 ## [Unreleased]
 
 ### Added
+- `AGE_PLUGIN_YUBIKEY_SKIP_NOT_FOUND` environment variable. When set, the
+  plugin silently skips identities for YubiKeys whose serial isn't currently
+  connected, instead of prompting the user to insert that specific YubiKey.
+  Useful for non-interactive contexts (e.g. deploys) and setups with multiple
+  YubiKeys where only one is connected at a time.
 - Support for the native non-hybrid tagged recipient type (`age1tag1..`).
   - Encryption requires making the `age-plugin-yubikey` binary available on the
     `PATH` as `age-plugin-tag`, or upgrading to a client version that builds in

--- a/src/key.rs
+++ b/src/key.rs
@@ -579,6 +579,12 @@ impl Stub {
         let mut yubikey = match open_by_serial(self.serial) {
             Ok(yk) => yk,
             Err(yubikey::Error::NotFound) => {
+
+                // Skips identities for non-connected YubiKeys without prompting
+                if std::env::var_os("AGE_PLUGIN_YUBIKEY_SKIP_NOT_FOUND").is_some() {
+                    return Ok(Ok(None));
+                }
+
                 let mut message = fl!("plugin-insert-yk", yubikey_serial = self.serial.to_string());
 
                 // If the `confirm` command is available, we loop until either the YubiKey


### PR DESCRIPTION
When set, the plugin silently returns no-identity for any stub whose YubiKey serial isn't currently connected, instead of issuing a `confirm` prompt asking the user to insert that specific YubiKey.

Motivation: in setups with multiple YubiKey identities (e.g. a primary and a backup, or per-device clones), every age decryption invocation prompts once per non-connected serial. In non-interactive contexts like clan/passage-driven deploys, the host renders the prompt but the user has to dismiss it once per secret being decrypted, which scales linearly with the number of secrets.

I personally have multiple YubiKeys withouth clear "primary" and want to be able to use any of them interchangeblely, e.g. in scripts.

The default behaviour is unchanged. Setting the env var is opt-in and documented in CHANGELOG.

Refs: https://github.com/str4d/age-plugin-yubikey/issues/178