### PR TITLE
Clean up clippy lints for newer toolchains

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -25,34 +25,34 @@ impl<'a, Kem> YubiKeyKemPrivateKey<'a, Kem> {
     fn new(conn: &'a mut Connection) -> Self {
         Self {
             conn: Rc::new(RwLock::new(conn)),
-            _kem: PhantomData::default(),
+            _kem: PhantomData,
         }
     }
 }
 
-impl<'a, Kem> Clone for YubiKeyKemPrivateKey<'a, Kem> {
+impl<Kem> Clone for YubiKeyKemPrivateKey<'_, Kem> {
     fn clone(&self) -> Self {
         Self {
             conn: self.conn.clone(),
-            _kem: PhantomData::default(),
+            _kem: PhantomData,
         }
     }
 }
 
-impl<'a, Kem> PartialEq for YubiKeyKemPrivateKey<'a, Kem> {
+impl<Kem> PartialEq for YubiKeyKemPrivateKey<'_, Kem> {
     fn eq(&self, other: &Self) -> bool {
         self.conn.read().unwrap().stub() == other.conn.read().unwrap().stub()
     }
 }
-impl<'a, Kem> Eq for YubiKeyKemPrivateKey<'a, Kem> {}
+impl<Kem> Eq for YubiKeyKemPrivateKey<'_, Kem> {}
 
-impl<'a, Kem: hpke::Kem> hpke::Serializable for YubiKeyKemPrivateKey<'a, Kem> {
+impl<Kem: hpke::Kem> hpke::Serializable for YubiKeyKemPrivateKey<'_, Kem> {
     type OutputSize = <Kem::PrivateKey as hpke::Serializable>::OutputSize;
     fn write_exact(&self, _: &mut [u8]) {
         unreachable!("Never called")
     }
 }
-impl<'a, Kem: hpke::Kem> hpke::Deserializable for YubiKeyKemPrivateKey<'a, Kem> {
+impl<Kem: hpke::Kem> hpke::Deserializable for YubiKeyKemPrivateKey<'_, Kem> {
     fn from_bytes(_: &[u8]) -> Result<Self, hpke::HpkeError> {
         unreachable!("Never called")
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -207,21 +207,12 @@ impl IdentityPluginV1 for IdentityPlugin {
         }
 
         // Sort by effectiveness (YubiKey that can trial-decrypt the most stanzas)
-        candidate_stanzas.sort_by_key(|(_, files)| {
-            files
-                .iter()
-                .map(|(_, stanzas)| stanzas.len())
-                .sum::<usize>()
-        });
+        candidate_stanzas
+            .sort_by_key(|(_, files)| files.values().map(|stanzas| stanzas.len()).sum::<usize>());
         candidate_stanzas.reverse();
         // Remove any YubiKeys without stanzas.
-        candidate_stanzas.retain(|(_, files)| {
-            files
-                .iter()
-                .map(|(_, stanzas)| stanzas.len())
-                .sum::<usize>()
-                > 0
-        });
+        candidate_stanzas
+            .retain(|(_, files)| files.values().map(|stanzas| stanzas.len()).sum::<usize>() > 0);
 
         for (stub, files) in candidate_stanzas.iter() {
             let mut conn = match stub.connect(&mut callbacks)? {


### PR DESCRIPTION
## Summary

Fixes clippy lints that surface under higher toolchains but are invisible under the repo's current MSRV `1.70`.
We have numerous important branches/PRs in flight that need to bump the toolchain.
It would be nice to cut down on the changes by preemptively addressing these.

<details>
<summary>Linting main on 1.85.0</summary>

Run the linting against main with toolchain 1.85.0:
```bash
docker run --rm -it \
  -e RUSTUP_TOOLCHAIN=1.85.0 \
  rust:1.85.0 \
  bash -c "cd /tmp && \
    git clone --depth 1 --branch main https://github.com/str4d/age-plugin-yubikey.git repo && \
    cd repo && \
    apt-get update >/dev/null && \
    apt-get install -y --no-install-recommends pkg-config libpcsclite-dev >/dev/null && \
    rustup component add clippy && \
    cargo clippy --all-features --all-targets -- -D warnings"
```
Errors:
```text
error: use of `default` to create a unit struct
  --> src/native.rs:28:30
   |
28 |             _kem: PhantomData::default(),
   |                              ^^^^^^^^^^^ help: remove this call to `default`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
   = note: `-D clippy::default-constructed-unit-structs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::default_constructed_unit_structs)]`

error: the following explicit lifetimes could be elided: 'a
  --> src/native.rs:33:6
   |
33 | impl<'a, Kem> Clone for YubiKeyKemPrivateKey<'a, Kem> {
   |      ^^                                      ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
   |
33 - impl<'a, Kem> Clone for YubiKeyKemPrivateKey<'a, Kem> {
33 + impl<Kem> Clone for YubiKeyKemPrivateKey<'_, Kem> {
   |

error: use of `default` to create a unit struct
  --> src/native.rs:37:30
   |
37 |             _kem: PhantomData::default(),
   |                              ^^^^^^^^^^^ help: remove this call to `default`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs

error: the following explicit lifetimes could be elided: 'a
  --> src/native.rs:42:6
   |
42 | impl<'a, Kem> PartialEq for YubiKeyKemPrivateKey<'a, Kem> {
   |      ^^                                          ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
42 - impl<'a, Kem> PartialEq for YubiKeyKemPrivateKey<'a, Kem> {
42 + impl<Kem> PartialEq for YubiKeyKemPrivateKey<'_, Kem> {
   |

error: the following explicit lifetimes could be elided: 'a
  --> src/native.rs:47:6
   |
47 | impl<'a, Kem> Eq for YubiKeyKemPrivateKey<'a, Kem> {}
   |      ^^                                   ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
47 - impl<'a, Kem> Eq for YubiKeyKemPrivateKey<'a, Kem> {}
47 + impl<Kem> Eq for YubiKeyKemPrivateKey<'_, Kem> {}
   |

error: the following explicit lifetimes could be elided: 'a
  --> src/native.rs:49:6
   |
49 | impl<'a, Kem: hpke::Kem> hpke::Serializable for YubiKeyKemPrivateKey<'a, Kem> {
   |      ^^                                                              ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
49 - impl<'a, Kem: hpke::Kem> hpke::Serializable for YubiKeyKemPrivateKey<'a, Kem> {
49 + impl<Kem: hpke::Kem> hpke::Serializable for YubiKeyKemPrivateKey<'_, Kem> {
   |

error: the following explicit lifetimes could be elided: 'a
  --> src/native.rs:55:6
   |
55 | impl<'a, Kem: hpke::Kem> hpke::Deserializable for YubiKeyKemPrivateKey<'a, Kem> {
   |      ^^                                                                ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
55 - impl<'a, Kem: hpke::Kem> hpke::Deserializable for YubiKeyKemPrivateKey<'a, Kem> {
55 + impl<Kem: hpke::Kem> hpke::Deserializable for YubiKeyKemPrivateKey<'_, Kem> {
   |
```
</details>

<details>
<summary>Linting main on 1.97.1</summary>

Run the linting against main with toolchain 1.97.1:
```bash
docker run --rm -it \
  -e RUSTUP_TOOLCHAIN=1.97.1 \
  rust:1.97.1 \
  bash -c "cd /tmp && \
    git clone --depth 1 --branch main https://github.com/str4d/age-plugin-yubikey.git repo && \
    cd repo && \
    apt-get update >/dev/null && \
    apt-get install -y --no-install-recommends pkg-config libpcsclite-dev >/dev/null && \
    rustup component add clippy && \
    cargo clippy --all-features --all-targets -- -D warnings"
```
Errors:
```text
error: use of `default` to create a unit struct
  --> src/native.rs:28:19
   |
28 |             _kem: PhantomData::default(),
   |                   ^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#default_constructed_unit_structs
   = note: `-D clippy::default-constructed-unit-structs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::default_constructed_unit_structs)]`
help: remove this call to `default`
   |
28 -             _kem: PhantomData::default(),
28 +             _kem: PhantomData,
   |

error: use of `default` to create a unit struct
  --> src/native.rs:37:19
   |
37 |             _kem: PhantomData::default(),
   |                   ^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#default_constructed_unit_structs
help: remove this call to `default`
   |
37 -             _kem: PhantomData::default(),
37 +             _kem: PhantomData,
   |

error: iterating on a map's values
   --> src/plugin.rs:211:13
    |
211 | /             files
212 | |                 .iter()
213 | |                 .map(|(_, stanzas)| stanzas.len())
    | |__________________________________________________^ help: try: `files.values().map(|stanzas| stanzas.len())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#iter_kv_map
    = note: `-D clippy::iter-kv-map` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::iter_kv_map)]`

error: iterating on a map's values
   --> src/plugin.rs:219:13
    |
219 | /             files
220 | |                 .iter()
221 | |                 .map(|(_, stanzas)| stanzas.len())
    | |__________________________________________________^ help: try: `files.values().map(|stanzas| stanzas.len())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#iter_kv_map
```
</details>

### Why `1.85.0` and `1.97.1`
`1.85.0`: From my current work and research, we are likely going to have to target this as our next MSRV to update our yubikey crate. I will be publishing a PR for that shortly.
`1.97.1`: It is current latest, may as well lint against it. 🤷

## How to Test this PR

<details>
<summary>1.85.0</summary>

```bash
docker run --rm -it \
  -e RUSTUP_TOOLCHAIN=1.85.0 \
  rust:1.85.0 \
  bash -c "cd /tmp && \
    git clone --depth 1 --branch feat/clippy-lint-prep https://github.com/Warfront1/age-plugin-yubikey.git repo && \
    cd repo && \
    apt-get update >/dev/null && \
    apt-get install -y --no-install-recommends pkg-config libpcsclite-dev >/dev/null && \
    rustup component add clippy && \
    cargo clippy --all-features --all-targets -- -D warnings"
```
</details>

<details>
<summary>1.97.1</summary>

```bash
docker run --rm -it \
  -e RUSTUP_TOOLCHAIN=1.97.1 \
  rust:1.97.1 \
  bash -c "cd /tmp && \
    git clone --depth 1 --branch feat/clippy-lint-prep https://github.com/Warfront1/age-plugin-yubikey.git repo && \
    cd repo && \
    apt-get update >/dev/null && \
    apt-get install -y --no-install-recommends pkg-config libpcsclite-dev >/dev/null && \
    rustup component add clippy && \
    cargo clippy --all-features --all-targets -- -D warnings"
```
</details>